### PR TITLE
Password salt is optional

### DIFF
--- a/jarvis_sdk_node/src/sdk/model/__test__/import_digitaltwin.test.ts
+++ b/jarvis_sdk_node/src/sdk/model/__test__/import_digitaltwin.test.ts
@@ -176,7 +176,6 @@ describe('when a new instance is created', () => {
           },
           password: {
             hash: Buffer.from('hashed-password'),
-            salt: Buffer.from('password-salt'),
           },
         },
       );
@@ -193,7 +192,7 @@ describe('when a new instance is created', () => {
             oneofKind: 'hash',
             hash: {
               passwordHash: Buffer.from('hashed-password'),
-              salt: Buffer.from('password-salt'),
+              salt: Buffer.from(''),
             },
           },
           uid: {

--- a/jarvis_sdk_node/src/sdk/model/import_digitaltwin.ts
+++ b/jarvis_sdk_node/src/sdk/model/import_digitaltwin.ts
@@ -19,7 +19,7 @@ export interface Mobile {
 
 export interface PasswordHash {
   hash: Buffer;
-  salt: Buffer;
+  salt?: Buffer;
 }
 
 export interface PasswordCredential {
@@ -159,7 +159,7 @@ export class ImportDigitalTwin extends DigitalTwin {
         oneofKind: 'hash' as const,
         hash: {
           passwordHash: this.password.password.hash.valueOf(),
-          salt: this.password.password.salt.valueOf(),
+          salt: (this.password.password.salt ?? Buffer.from('')).valueOf(),
         },
       };
     }


### PR DESCRIPTION
When you import a digital twin, the password salt will be optional.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: ./CONTRIBUTING.md
-->

<!-- _Please make sure to review and check all of these items:_ -->

# Description

<!-- Please provide a description of the change here. -->

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

# Checklist

- [ ] `make test` passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](./doc/guides/commit-message.md#commit-message-guidelines)

## CHANGELOG

<!-- Please provide a brief description of changes here. -->
<!-- - [FIX] Fix a bug -->

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->
