### PR TITLE
Refresh connection after some idle time

### DIFF
--- a/jarvis_sdk_node/src/sdk/utils/stream/__test__/index_fixer.test.ts
+++ b/jarvis_sdk_node/src/sdk/utils/stream/__test__/index_fixer.test.ts
@@ -1,0 +1,162 @@
+import IndexFixer from '../index_fixer';
+
+const onDataResolver = <T extends string>(indexFixer: IndexFixer<T>, data: unknown) => {
+  return new Promise((resolve) => {
+    indexFixer.onData(data, (returnedValue: unknown) => {
+      resolve(returnedValue);
+    });
+  });
+};
+
+describe('when data is not an object', () => {
+  let indexFixer: IndexFixer<'prop'>;
+
+  beforeEach(() => {
+    indexFixer = new IndexFixer('prop');
+  });
+
+  it('returns the original value', () => {
+    expect(onDataResolver(indexFixer, null)).resolves.toBe(null);
+    expect(onDataResolver(indexFixer, 'abc')).resolves.toBe('abc');
+    expect(onDataResolver(indexFixer, 42)).resolves.toBe(42);
+    expect(onDataResolver(indexFixer, true)).resolves.toBe(true);
+  });
+});
+
+describe('when data does not contain required property', () => {
+  let indexFixer: IndexFixer<'prop'>;
+
+  beforeEach(() => {
+    indexFixer = new IndexFixer('prop');
+  });
+
+  it('returns the original value', () => {
+    expect(onDataResolver(indexFixer, { key: 'value' })).resolves.toEqual({ key: 'value' });
+  });
+});
+
+describe('when data contains required property', () => {
+  let indexFixer: IndexFixer<'prop'>;
+
+  beforeEach(() => {
+    indexFixer = new IndexFixer('prop');
+  });
+
+  describe('when the index is a string', () => {
+    it('returns the original value', () => {
+      expect(onDataResolver(indexFixer, { prop: '0' })).resolves.toEqual({ prop: '0' });
+      expect(onDataResolver(indexFixer, { prop: '1' })).resolves.toEqual({ prop: '1' });
+      expect(onDataResolver(indexFixer, { prop: '2' })).resolves.toEqual({ prop: '2' });
+    });
+
+    describe('when the client is closed after some records', () => {
+      beforeEach(async () => {
+        await onDataResolver(indexFixer, { prop: '0' });
+        await onDataResolver(indexFixer, { prop: '2' });
+        await onDataResolver(indexFixer, { prop: '1' });
+        await indexFixer.onClientClosed();
+      });
+
+      it('returns shifted values', () => {
+        expect(onDataResolver(indexFixer, { prop: '0' })).resolves.toEqual({ prop: '3' });
+        expect(onDataResolver(indexFixer, { prop: '1' })).resolves.toEqual({ prop: '4' });
+        expect(onDataResolver(indexFixer, { prop: '2' })).resolves.toEqual({ prop: '5' });
+      });
+    });
+  });
+
+  describe('when the index is a number', () => {
+    it('returns the original value', () => {
+      expect(onDataResolver(indexFixer, { prop: 0 })).resolves.toEqual({ prop: 0 });
+      expect(onDataResolver(indexFixer, { prop: 1 })).resolves.toEqual({ prop: 1 });
+      expect(onDataResolver(indexFixer, { prop: 2 })).resolves.toEqual({ prop: 2 });
+    });
+
+    describe('when the client is closed after some records', () => {
+      beforeEach(async () => {
+        await onDataResolver(indexFixer, { prop: 0 });
+        await onDataResolver(indexFixer, { prop: 1 });
+        await onDataResolver(indexFixer, { prop: 2 });
+        await indexFixer.onClientClosed();
+      });
+
+      it('returns shifted values', () => {
+        expect(onDataResolver(indexFixer, { prop: 0 })).resolves.toEqual({ prop: 3 });
+        expect(onDataResolver(indexFixer, { prop: 1 })).resolves.toEqual({ prop: 4 });
+        expect(onDataResolver(indexFixer, { prop: 2 })).resolves.toEqual({ prop: 5 });
+      });
+    });
+  });
+});
+
+describe('when data is an array of objects containing the required property', () => {
+  let indexFixer: IndexFixer<'prop'>;
+
+  beforeEach(() => {
+    indexFixer = new IndexFixer('prop');
+  });
+
+  it('returns the original value', () => {
+    expect(onDataResolver(indexFixer, [{ prop: 0 }, { prop: 1 }, { prop: 2 }])).resolves.toEqual([
+      { prop: 0 },
+      { prop: 1 },
+      { prop: 2 },
+    ]);
+  });
+
+  describe('when the client is closed after some records', () => {
+    beforeEach(async () => {
+      await onDataResolver(indexFixer, [{ prop: 1 }, { prop: 0 }, { prop: 2 }]);
+      await indexFixer.onClientClosed();
+    });
+
+    it('returns shifted values', () => {
+      expect(onDataResolver(indexFixer, [{ prop: 0 }, { prop: 1 }, { prop: 2 }])).resolves.toEqual([
+        { prop: 3 },
+        { prop: 4 },
+        { prop: 5 },
+      ]);
+    });
+  });
+});
+
+describe('when data is an object containing a subobject with the required property', () => {
+  let indexFixer: IndexFixer<'prop.index'>;
+
+  beforeEach(() => {
+    indexFixer = new IndexFixer('prop.index');
+  });
+
+  it('returns the original value', () => {
+    expect(onDataResolver(indexFixer, { prop: { index: '0' } })).resolves.toEqual({
+      prop: { index: '0' },
+    });
+    expect(onDataResolver(indexFixer, { prop: { index: '1' } })).resolves.toEqual({
+      prop: { index: '1' },
+    });
+    expect(onDataResolver(indexFixer, { prop: { index: '2' } })).resolves.toEqual({
+      prop: { index: '2' },
+    });
+  });
+
+  describe('when the client is closed after some records', () => {
+    beforeEach(async () => {
+      await onDataResolver(indexFixer, { prop: { index: '0' } });
+      await onDataResolver(indexFixer, { prop: { index: '2' } });
+      await onDataResolver(indexFixer, { prop: { index: '1' } });
+      await indexFixer.onClientClosed();
+    });
+
+    it('returns shifted values', () => {
+      expect(onDataResolver(indexFixer, { prop: { index: '0' } })).resolves.toEqual({
+        prop: { index: '3' },
+      });
+      expect(onDataResolver(indexFixer, { prop: { index: '1' } })).resolves.toEqual({
+        prop: { index: '4' },
+      });
+      expect(onDataResolver(indexFixer, { prop: { index: '2' } })).resolves.toEqual({
+        prop: { index: '5' },
+      });
+    });
+  });
+});

--- a/jarvis_sdk_node/src/sdk/utils/stream/index.ts
+++ b/jarvis_sdk_node/src/sdk/utils/stream/index.ts
@@ -1,0 +1,3 @@
+export { default as streamKeeper } from './stream_keeper';
+export { default as streamSplitter } from './stream_splitter';
+export { default as IndexFixer } from './index_fixer';

--- a/jarvis_sdk_node/src/sdk/utils/stream/index_fixer.ts
+++ b/jarvis_sdk_node/src/sdk/utils/stream/index_fixer.ts
@@ -1,0 +1,65 @@
+export interface OutputModifier {
+  onClientClosed: () => Promise<void>;
+  onData: (data: unknown, next: (modifiedData: unknown) => void) => Promise<void>;
+}
+
+class IndexFixer<T extends string> implements OutputModifier {
+  private startIndex = 0;
+  private nextIndex = 0;
+
+  constructor(private indexPropName: T) {}
+
+  async onClientClosed(): Promise<void> {
+    this.startIndex = this.nextIndex;
+  }
+
+  async onData(data: unknown, next: (modifiedData: unknown) => void): Promise<void> {
+    const fixedData = await this.processData(data, this.indexPropName);
+    next(fixedData);
+  }
+
+  private async processData(data: unknown, path: string): Promise<unknown> {
+    if (Array.isArray(data)) {
+      return await Promise.all(data.map((datum) => this.processData(datum, path)));
+    }
+
+    if (path.includes('.') && typeof data === 'object' && data !== null) {
+      const execResult = /^([^.]*)\.(.*)$/.exec(path);
+      if (execResult) {
+        const topPropertyName = execResult[1];
+        const restPropertyPath = execResult[2];
+        const processedProperty = await this.processData(
+          (data as Record<string, unknown>)[topPropertyName],
+          restPropertyPath,
+        );
+        return {
+          ...data,
+          [topPropertyName]: processedProperty,
+        };
+      }
+    }
+
+    const hasIndexProp = (data: unknown): data is Record<string, unknown> => {
+      return typeof data === 'object' && data !== null && path in data;
+    };
+
+    if (hasIndexProp(data) && ['string', 'number'].includes(typeof data[path])) {
+      const isIndexString = typeof data[path] === 'string';
+      const parsedIndex: number = isIndexString
+        ? Number.parseInt(data[path] as string)
+        : (data[path] as number);
+      data[path] = parsedIndex + this.startIndex;
+      const newNextIndex = (data[path] as number) + 1;
+      if (newNextIndex > this.nextIndex) {
+        this.nextIndex = newNextIndex;
+      }
+      if (isIndexString) {
+        data[path] = (data[path] as number).toString();
+      }
+    }
+
+    return data;
+  }
+}
+
+export default IndexFixer;

--- a/jarvis_sdk_node/src/sdk/utils/stream/stream_keeper/__test__/stream_keeper.test.ts
+++ b/jarvis_sdk_node/src/sdk/utils/stream/stream_keeper/__test__/stream_keeper.test.ts
@@ -1,0 +1,666 @@
+import { ClientDuplexStream } from '@grpc/grpc-js';
+import { Duplex, Readable, Writable } from 'stream';
+import IndexFixer from '../../index_fixer';
+import streamKeeper from '../stream_keeper';
+
+class DuplexWithMetadata extends Duplex {
+  public testIndex = 0;
+  public isClosed = false;
+}
+
+const getStreamResults = async (stream: Readable): Promise<unknown[]> => {
+  return new Promise((resolve, reject) => {
+    const results: unknown[] = [];
+    stream.on('data', (data: unknown) => {
+      results.push(data);
+    });
+    stream.on('end', () => {
+      resolve(results);
+    });
+    stream.on('error', (err) => {
+      reject(err);
+    });
+  });
+};
+
+const timeouts: Record<number, { fn: () => void; isClientTimeout: boolean }> = {};
+
+const runUnusedClientTimeouts = () => {
+  Object.values(timeouts).forEach((timeout) => {
+    if (!timeout.isClientTimeout) {
+      timeout.fn();
+    }
+  });
+};
+
+const runClientTimeouts = () => {
+  Object.values(timeouts).forEach((timeout) => {
+    if (timeout.isClientTimeout) {
+      timeout.fn();
+    }
+  });
+};
+
+beforeEach(() => {
+  jest.spyOn(global, 'setTimeout').mockImplementation((cb, timeout) => {
+    const allIndexes = Object.keys(timeouts).map((index) => Number.parseInt(index));
+    const index = allIndexes.length > 0 ? Math.max(...allIndexes) + 1 : 0;
+    timeouts[index] = {
+      isClientTimeout: timeout === 30 * 1000,
+      fn: cb,
+    };
+
+    return index as unknown as NodeJS.Timeout;
+  });
+  jest.spyOn(global, 'clearTimeout').mockImplementation((index) => {
+    delete timeouts[index as number];
+  });
+});
+
+afterEach(() => {
+  (setTimeout as unknown as jest.SpyInstance).mockRestore();
+  (clearTimeout as unknown as jest.SpyInstance).mockRestore();
+});
+
+describe('when no modifier is used', () => {
+  let input: Writable;
+  let output: Readable;
+  let results: unknown;
+  let streamKeeperFnSpy: jest.SpyInstance;
+
+  beforeEach(async () => {
+    streamKeeperFnSpy = jest.fn().mockImplementation(() => {
+      const clientStreamWrite = jest.fn().mockImplementation((chunk, encoding, next) => {
+        clientStream.push({ ...chunk, index: clientStream.testIndex++ }, encoding);
+        next();
+      });
+      const clientStream: DuplexWithMetadata = new DuplexWithMetadata({
+        write: clientStreamWrite,
+        read: () => {
+          //
+        },
+        objectMode: true,
+      });
+      jest.spyOn(clientStream, 'end').mockImplementation(() => {
+        clientStream.push(null);
+        clientStream.isClosed = true;
+        return clientStream;
+      });
+      clientStream.testIndex = 0;
+      return clientStream;
+    });
+    [input, output] = streamKeeper(
+      streamKeeperFnSpy as unknown as () => ClientDuplexStream<unknown, unknown>,
+    );
+  });
+
+  describe('when the input stream is closed', () => {
+    beforeEach(async () => {
+      input.end();
+      results = await getStreamResults(output);
+    });
+
+    it('returns no results', () => {
+      expect(results).toEqual([]);
+    });
+  });
+
+  describe('when there is an error in the input stream', () => {
+    let thrownError: Error;
+
+    beforeEach(async () => {
+      input.destroy(new Error('Input stream error'));
+      return getStreamResults(output).catch((error) => {
+        thrownError = error;
+      });
+    });
+
+    it('throws the error', () => {
+      expect(thrownError).toEqual(new Error('Input stream error'));
+    });
+  });
+
+  describe('when an item is pushed to the input stream', () => {
+    beforeEach(async () => {
+      input.write({ email: 'test_email+1@gmail.com' });
+    });
+
+    describe('when the input stream is closed', () => {
+      beforeEach(async () => {
+        input.end();
+        results = await getStreamResults(output);
+      });
+
+      it('returns correct results', () => {
+        expect(results).toEqual([{ email: 'test_email+1@gmail.com', index: 0 }]);
+      });
+    });
+
+    describe('when there is an error in the input stream', () => {
+      let thrownError: Error;
+
+      beforeEach(async () => {
+        input.destroy(new Error('Input stream error'));
+        return getStreamResults(output).catch((error) => {
+          thrownError = error;
+        });
+      });
+
+      it('throws the error', () => {
+        expect(thrownError).toEqual(new Error('Input stream error'));
+      });
+    });
+
+    describe('when another item is pushed to the input stream', () => {
+      beforeEach(async () => {
+        input.write({ email: 'test_email+2@gmail.com' });
+      });
+
+      it('keeps the stream opened', () => {
+        expect(streamKeeperFnSpy.mock.results[0].value.isClosed).toEqual(false);
+      });
+
+      describe('when the input stream is closed', () => {
+        beforeEach(async () => {
+          input.end();
+          results = await getStreamResults(output);
+        });
+
+        it('returns correct results', () => {
+          expect(results).toEqual([
+            { email: 'test_email+1@gmail.com', index: 0 },
+            { email: 'test_email+2@gmail.com', index: 1 },
+          ]);
+        });
+      });
+
+      describe('when the unused client timeout is up', () => {
+        beforeEach(async () => {
+          runUnusedClientTimeouts();
+        });
+
+        it('closes the stream', () => {
+          expect(streamKeeperFnSpy.mock.results[0].value.isClosed).toEqual(true);
+        });
+
+        describe('when the input stream is closed', () => {
+          beforeEach(async () => {
+            input.end();
+            results = await getStreamResults(output);
+          });
+
+          it('returns correct results', () => {
+            expect(results).toEqual([
+              { email: 'test_email+1@gmail.com', index: 0 },
+              { email: 'test_email+2@gmail.com', index: 1 },
+            ]);
+          });
+        });
+
+        describe('when another item is pushed to the input stream', () => {
+          beforeEach(async () => {
+            input.write({ email: 'test_email+3@gmail.com' });
+          });
+
+          it('opens a new stream', () => {
+            expect(streamKeeperFnSpy.mock.results[0].value.isClosed).toEqual(true);
+            expect(streamKeeperFnSpy.mock.results[1].value.isClosed).toEqual(false);
+          });
+
+          describe('when the input stream is closed', () => {
+            beforeEach(async () => {
+              input.end();
+              results = await getStreamResults(output);
+            });
+
+            it('returns correct results', () => {
+              expect(results).toEqual([
+                { email: 'test_email+1@gmail.com', index: 0 },
+                { email: 'test_email+2@gmail.com', index: 1 },
+                { email: 'test_email+3@gmail.com', index: 0 },
+              ]);
+            });
+          });
+        });
+
+        describe('when the client timeout is up', () => {
+          beforeEach(async () => {
+            runClientTimeouts();
+          });
+
+          it('closes the stream', () => {
+            expect(streamKeeperFnSpy.mock.results[0].value.isClosed).toEqual(true);
+          });
+
+          describe('when the input stream is closed', () => {
+            beforeEach(async () => {
+              input.end();
+              results = await getStreamResults(output);
+            });
+
+            it('returns correct results', () => {
+              expect(results).toEqual([
+                { email: 'test_email+1@gmail.com', index: 0 },
+                { email: 'test_email+2@gmail.com', index: 1 },
+              ]);
+            });
+          });
+
+          describe('when another item is pushed to the input stream', () => {
+            beforeEach(async () => {
+              input.write({ email: 'test_email+3@gmail.com' });
+            });
+
+            it('opens a new stream', () => {
+              expect(streamKeeperFnSpy.mock.results[0].value.isClosed).toEqual(true);
+              expect(streamKeeperFnSpy.mock.results[1].value.isClosed).toEqual(false);
+            });
+
+            describe('when the input stream is closed', () => {
+              beforeEach(async () => {
+                input.end();
+                results = await getStreamResults(output);
+              });
+
+              it('returns correct results', () => {
+                expect(results).toEqual([
+                  { email: 'test_email+1@gmail.com', index: 0 },
+                  { email: 'test_email+2@gmail.com', index: 1 },
+                  { email: 'test_email+3@gmail.com', index: 0 },
+                ]);
+              });
+            });
+          });
+        });
+      });
+
+      describe('when the client timeout is up', () => {
+        beforeEach(async () => {
+          runClientTimeouts();
+        });
+
+        it('closes the stream', () => {
+          expect(streamKeeperFnSpy.mock.results[0].value.isClosed).toEqual(true);
+        });
+
+        describe('when the input stream is closed', () => {
+          beforeEach(async () => {
+            input.end();
+            results = await getStreamResults(output);
+          });
+
+          it('returns correct results', () => {
+            expect(results).toEqual([
+              { email: 'test_email+1@gmail.com', index: 0 },
+              { email: 'test_email+2@gmail.com', index: 1 },
+            ]);
+          });
+        });
+
+        describe('when another item is pushed to the input stream', () => {
+          beforeEach(async () => {
+            input.write({ email: 'test_email+3@gmail.com' });
+          });
+
+          it('opens a new stream', () => {
+            expect(streamKeeperFnSpy.mock.results[0].value.isClosed).toEqual(true);
+            expect(streamKeeperFnSpy.mock.results[1].value.isClosed).toEqual(false);
+          });
+
+          describe('when the input stream is closed', () => {
+            beforeEach(async () => {
+              input.end();
+              results = await getStreamResults(output);
+            });
+
+            it('returns correct results', () => {
+              expect(results).toEqual([
+                { email: 'test_email+1@gmail.com', index: 0 },
+                { email: 'test_email+2@gmail.com', index: 1 },
+                { email: 'test_email+3@gmail.com', index: 0 },
+              ]);
+            });
+          });
+        });
+
+        describe('when the unused client timeout is up', () => {
+          beforeEach(async () => {
+            runUnusedClientTimeouts();
+          });
+
+          it('closes the stream', () => {
+            expect(streamKeeperFnSpy.mock.results[0].value.isClosed).toEqual(true);
+          });
+
+          describe('when another item is pushed to the input stream', () => {
+            beforeEach(async () => {
+              input.write({ email: 'test_email+3@gmail.com' });
+            });
+
+            it('opens a new stream', () => {
+              expect(streamKeeperFnSpy.mock.results[0].value.isClosed).toEqual(true);
+              expect(streamKeeperFnSpy.mock.results[1].value.isClosed).toEqual(false);
+            });
+
+            describe('when the input stream is closed', () => {
+              beforeEach(async () => {
+                input.end();
+                results = await getStreamResults(output);
+              });
+
+              it('returns correct results', () => {
+                expect(results).toEqual([
+                  { email: 'test_email+1@gmail.com', index: 0 },
+                  { email: 'test_email+2@gmail.com', index: 1 },
+                  { email: 'test_email+3@gmail.com', index: 0 },
+                ]);
+              });
+            });
+          });
+        });
+      });
+    });
+  });
+});
+
+describe('when index fixer modifier is used', () => {
+  let input: Writable;
+  let output: Readable;
+  let results: unknown;
+  let streamKeeperFnSpy: jest.SpyInstance;
+
+  beforeEach(async () => {
+    streamKeeperFnSpy = jest.fn().mockImplementation(() => {
+      const clientStreamWrite = jest.fn().mockImplementation((chunk, encoding, next) => {
+        clientStream.push({ ...chunk, index: clientStream.testIndex++ }, encoding);
+        next();
+      });
+      const clientStream: DuplexWithMetadata = new DuplexWithMetadata({
+        write: clientStreamWrite,
+        read: () => {
+          //
+        },
+        objectMode: true,
+      });
+      jest.spyOn(clientStream, 'end').mockImplementation(() => {
+        clientStream.push(null);
+        clientStream.isClosed = true;
+        return clientStream;
+      });
+      clientStream.testIndex = 0;
+      return clientStream;
+    });
+    [input, output] = streamKeeper(
+      streamKeeperFnSpy as unknown as () => ClientDuplexStream<unknown, unknown>,
+      [new IndexFixer('index')],
+    );
+  });
+
+  describe('when the input stream is closed', () => {
+    beforeEach(async () => {
+      input.end();
+      results = await getStreamResults(output);
+    });
+
+    it('returns no results', () => {
+      expect(results).toEqual([]);
+    });
+  });
+
+  describe('when there is an error in the input stream', () => {
+    let thrownError: Error;
+
+    beforeEach(async () => {
+      input.destroy(new Error('Input stream error'));
+      return getStreamResults(output).catch((error) => {
+        thrownError = error;
+      });
+    });
+
+    it('throws the error', () => {
+      expect(thrownError).toEqual(new Error('Input stream error'));
+    });
+  });
+
+  describe('when an item is pushed to the input stream', () => {
+    beforeEach(async () => {
+      input.write({ email: 'test_email+1@gmail.com' });
+    });
+
+    describe('when the input stream is closed', () => {
+      beforeEach(async () => {
+        input.end();
+        results = await getStreamResults(output);
+      });
+
+      it('returns correct results', () => {
+        expect(results).toEqual([{ email: 'test_email+1@gmail.com', index: 0 }]);
+      });
+    });
+
+    describe('when there is an error in the input stream', () => {
+      let thrownError: Error;
+
+      beforeEach(async () => {
+        input.destroy(new Error('Input stream error'));
+        return getStreamResults(output).catch((error) => {
+          thrownError = error;
+        });
+      });
+
+      it('throws the error', () => {
+        expect(thrownError).toEqual(new Error('Input stream error'));
+      });
+    });
+
+    describe('when another item is pushed to the input stream', () => {
+      beforeEach(async () => {
+        input.write({ email: 'test_email+2@gmail.com' });
+      });
+
+      it('keeps the stream opened', () => {
+        expect(streamKeeperFnSpy.mock.results[0].value.isClosed).toEqual(false);
+      });
+
+      describe('when the input stream is closed', () => {
+        beforeEach(async () => {
+          input.end();
+          results = await getStreamResults(output);
+        });
+
+        it('returns correct results', () => {
+          expect(results).toEqual([
+            { email: 'test_email+1@gmail.com', index: 0 },
+            { email: 'test_email+2@gmail.com', index: 1 },
+          ]);
+        });
+      });
+
+      describe('when the unused client timeout is up', () => {
+        beforeEach(async () => {
+          runUnusedClientTimeouts();
+        });
+
+        it('closes the stream', () => {
+          expect(streamKeeperFnSpy.mock.results[0].value.isClosed).toEqual(true);
+        });
+
+        describe('when the input stream is closed', () => {
+          beforeEach(async () => {
+            input.end();
+            results = await getStreamResults(output);
+          });
+
+          it('returns correct results', () => {
+            expect(results).toEqual([
+              { email: 'test_email+1@gmail.com', index: 0 },
+              { email: 'test_email+2@gmail.com', index: 1 },
+            ]);
+          });
+        });
+
+        describe('when another item is pushed to the input stream', () => {
+          beforeEach(async () => {
+            input.write({ email: 'test_email+3@gmail.com' });
+          });
+
+          it('opens a new stream', () => {
+            expect(streamKeeperFnSpy.mock.results[0].value.isClosed).toEqual(true);
+            expect(streamKeeperFnSpy.mock.results[1].value.isClosed).toEqual(false);
+          });
+
+          describe('when the input stream is closed', () => {
+            beforeEach(async () => {
+              input.end();
+              results = await getStreamResults(output);
+            });
+
+            it('returns correct results', () => {
+              expect(results).toEqual([
+                { email: 'test_email+1@gmail.com', index: 0 },
+                { email: 'test_email+2@gmail.com', index: 1 },
+                { email: 'test_email+3@gmail.com', index: 2 },
+              ]);
+            });
+          });
+        });
+
+        describe('when the client timeout is up', () => {
+          beforeEach(async () => {
+            runClientTimeouts();
+          });
+
+          it('closes the stream', () => {
+            expect(streamKeeperFnSpy.mock.results[0].value.isClosed).toEqual(true);
+          });
+
+          describe('when the input stream is closed', () => {
+            beforeEach(async () => {
+              input.end();
+              results = await getStreamResults(output);
+            });
+
+            it('returns correct results', () => {
+              expect(results).toEqual([
+                { email: 'test_email+1@gmail.com', index: 0 },
+                { email: 'test_email+2@gmail.com', index: 1 },
+              ]);
+            });
+          });
+
+          describe('when another item is pushed to the input stream', () => {
+            beforeEach(async () => {
+              input.write({ email: 'test_email+3@gmail.com' });
+            });
+
+            it('opens a new stream', () => {
+              expect(streamKeeperFnSpy.mock.results[0].value.isClosed).toEqual(true);
+              expect(streamKeeperFnSpy.mock.results[1].value.isClosed).toEqual(false);
+            });
+
+            describe('when the input stream is closed', () => {
+              beforeEach(async () => {
+                input.end();
+                results = await getStreamResults(output);
+              });
+
+              it('returns correct results', () => {
+                expect(results).toEqual([
+                  { email: 'test_email+1@gmail.com', index: 0 },
+                  { email: 'test_email+2@gmail.com', index: 1 },
+                  { email: 'test_email+3@gmail.com', index: 2 },
+                ]);
+              });
+            });
+          });
+        });
+      });
+
+      describe('when the client timeout is up', () => {
+        beforeEach(async () => {
+          runClientTimeouts();
+        });
+
+        it('closes the stream', () => {
+          expect(streamKeeperFnSpy.mock.results[0].value.isClosed).toEqual(true);
+        });
+
+        describe('when the input stream is closed', () => {
+          beforeEach(async () => {
+            input.end();
+            results = await getStreamResults(output);
+          });
+
+          it('returns correct results', () => {
+            expect(results).toEqual([
+              { email: 'test_email+1@gmail.com', index: 0 },
+              { email: 'test_email+2@gmail.com', index: 1 },
+            ]);
+          });
+        });
+
+        describe('when another item is pushed to the input stream', () => {
+          beforeEach(async () => {
+            input.write({ email: 'test_email+3@gmail.com' });
+          });
+
+          it('opens a new stream', () => {
+            expect(streamKeeperFnSpy.mock.results[0].value.isClosed).toEqual(true);
+            expect(streamKeeperFnSpy.mock.results[1].value.isClosed).toEqual(false);
+          });
+
+          describe('when the input stream is closed', () => {
+            beforeEach(async () => {
+              input.end();
+              results = await getStreamResults(output);
+            });
+
+            it('returns correct results', () => {
+              expect(results).toEqual([
+                { email: 'test_email+1@gmail.com', index: 0 },
+                { email: 'test_email+2@gmail.com', index: 1 },
+                { email: 'test_email+3@gmail.com', index: 2 },
+              ]);
+            });
+          });
+        });
+
+        describe('when the unused client timeout is up', () => {
+          beforeEach(async () => {
+            runUnusedClientTimeouts();
+          });
+
+          it('closes the stream', () => {
+            expect(streamKeeperFnSpy.mock.results[0].value.isClosed).toEqual(true);
+          });
+
+          describe('when another item is pushed to the input stream', () => {
+            beforeEach(async () => {
+              input.write({ email: 'test_email+3@gmail.com' });
+            });
+
+            it('opens a new stream', () => {
+              expect(streamKeeperFnSpy.mock.results[0].value.isClosed).toEqual(true);
+              expect(streamKeeperFnSpy.mock.results[1].value.isClosed).toEqual(false);
+            });
+
+            describe('when the input stream is closed', () => {
+              beforeEach(async () => {
+                input.end();
+                results = await getStreamResults(output);
+              });
+
+              it('returns correct results', () => {
+                expect(results).toEqual([
+                  { email: 'test_email+1@gmail.com', index: 0 },
+                  { email: 'test_email+2@gmail.com', index: 1 },
+                  { email: 'test_email+3@gmail.com', index: 2 },
+                ]);
+              });
+            });
+          });
+        });
+      });
+    });
+  });
+});

--- a/jarvis_sdk_node/src/sdk/utils/stream/stream_keeper/client_output.ts
+++ b/jarvis_sdk_node/src/sdk/utils/stream/stream_keeper/client_output.ts
@@ -1,0 +1,128 @@
+import { ClientDuplexStream } from '@grpc/grpc-js/build/src/call';
+import { Duplex } from 'stream';
+
+export interface OutputModifier {
+  onClientClosed: () => void;
+  onData: (data: unknown, next: (modifiedData: unknown) => void) => Promise<void>;
+}
+
+class ClientOutput<RequestType, ResponseType> extends Duplex {
+  private inputEnd: Error | boolean = false;
+  private clients: ClientDuplexStream<RequestType, ResponseType>[] = [];
+  private processingPromise = Promise.resolve();
+  private futureData: { client: ClientDuplexStream<RequestType, ResponseType>; chunk: unknown }[] =
+    [];
+
+  constructor(private modifiers: OutputModifier[] = []) {
+    super({
+      write: (chunk, encoding, next) => {
+        this.push(chunk, encoding);
+        next();
+      },
+      read: () => {
+        // There's no need to do anything
+      },
+      destroy: (err, next) => {
+        next(err);
+      },
+      objectMode: true,
+    });
+  }
+
+  addGrpcClient(client: ClientDuplexStream<RequestType, ResponseType>): void {
+    this.clients.push(client);
+
+    client.on('data', async (chunk) => {
+      this.processData(client, chunk);
+    });
+
+    client.on('end', () => {
+      this.processingPromise = this.processingPromise.then(() => {
+        const currentClientIndex = this.clients.indexOf(client);
+        this.clients.splice(currentClientIndex, 1);
+        this.modifiers.forEach((modifier) => modifier.onClientClosed());
+
+        // If we had (or still have) more opened clients and we already got some data
+        // from the newer clients, they are buffered in the futureData array. As the
+        // old client was closed we need to check whether we can process the buffered
+        // data now.
+        if (this.futureData.length > 0) {
+          const futureData = this.futureData;
+          this.futureData = [];
+          futureData.forEach((data) => {
+            this.processData(data.client, data.chunk);
+          });
+        }
+
+        // If we don't have any other clients opened, we can close the output stream.
+        if (!this.hasClients()) {
+          this.finish();
+        }
+      });
+    });
+    client.on('error', (error) => {
+      this.processingPromise = this.processingPromise.then(() => {
+        this.destroy(error);
+      });
+    });
+  }
+
+  end(): this {
+    this.processingPromise = this.processingPromise.then(() => {
+      super.end(() => {
+        this.emit('end');
+      });
+    });
+
+    return this;
+  }
+
+  hasClients(): boolean {
+    return this.clients.length > 0;
+  }
+
+  setInputEnd(error: Error | null): void {
+    this.inputEnd = error ?? true;
+    if (!this.hasClients()) {
+      this.finish();
+    }
+  }
+
+  private finish() {
+    if (this.inputEnd === true) {
+      this.end();
+    } else if (this.inputEnd instanceof Error) {
+      this.destroy(this.inputEnd);
+    }
+  }
+
+  private processData(client: ClientDuplexStream<RequestType, ResponseType>, chunk: unknown) {
+    // The client on index 0 is the oldest opened client. If we have opened more clients, we want
+    // to process data related only to the oldest client (we might want to re-index returned objects
+    // and if we would mix responses from different clients, then we would end up in inconsistent indexes).
+    if (client !== this.clients[0]) {
+      this.futureData.push({ client, chunk });
+      return;
+    }
+
+    this.processingPromise = this.processingPromise.then(async () => {
+      let modifiedChunk = chunk;
+      let modifierIndex = 0;
+      while (modifierIndex < this.modifiers.length) {
+        modifiedChunk = await new Promise((resolve) => {
+          const cb = (newChunk: unknown) => {
+            ++modifierIndex;
+            resolve(newChunk);
+          };
+
+          const modifier = this.modifiers[modifierIndex];
+          modifier.onData(modifiedChunk, cb);
+        });
+      }
+
+      this.write(modifiedChunk);
+    });
+  }
+}
+
+export default ClientOutput;

--- a/jarvis_sdk_node/src/sdk/utils/stream/stream_keeper/index.ts
+++ b/jarvis_sdk_node/src/sdk/utils/stream/stream_keeper/index.ts
@@ -1,0 +1,1 @@
+export { default } from './stream_keeper';

--- a/jarvis_sdk_node/src/sdk/utils/stream/stream_keeper/stream_keeper.ts
+++ b/jarvis_sdk_node/src/sdk/utils/stream/stream_keeper/stream_keeper.ts
@@ -1,0 +1,88 @@
+import { ClientDuplexStream } from '@grpc/grpc-js';
+import { Readable, Writable } from 'stream';
+import ClientOutput, { OutputModifier } from './client_output';
+
+const streamKeeper = <RequestType, ResponseType>(
+  fn: () => ClientDuplexStream<RequestType, ResponseType>,
+  modifiers?: OutputModifier[],
+): [Writable, Readable] => {
+  let currentClient: ClientDuplexStream<RequestType, ResponseType> | null = null;
+  let unusedClientTimeout: NodeJS.Timeout | null = null;
+  let currentClientTimeout: NodeJS.Timeout | null = null;
+
+  const output = new ClientOutput<RequestType, ResponseType>(modifiers);
+
+  const clearTimeouts = () => {
+    if (unusedClientTimeout) {
+      clearTimeout(unusedClientTimeout);
+      unusedClientTimeout = null;
+    }
+  };
+
+  const clearAllTimeouts = () => {
+    clearTimeouts();
+
+    if (currentClientTimeout) {
+      clearTimeout(currentClientTimeout);
+      currentClientTimeout = null;
+    }
+  };
+
+  const input = new Writable({
+    write: (chunk, encoding, next) => {
+      if (!currentClient) {
+        currentClient = fn();
+
+        output.addGrpcClient(currentClient);
+        currentClient.on('end', () => {
+          clearAllTimeouts();
+        });
+      }
+
+      clearTimeouts();
+
+      // If there is nothing sent in 10 seconds, close the connection
+      unusedClientTimeout = setTimeout(() => {
+        clearAllTimeouts();
+        if (currentClient) {
+          currentClient.end();
+          currentClient = null;
+        }
+      }, 1000 * 10);
+
+      // If the connection is opened for more than 30 seconds, close the connection
+      if (!currentClientTimeout) {
+        currentClientTimeout = setTimeout(() => {
+          clearAllTimeouts();
+          if (currentClient) {
+            currentClient.end();
+            currentClient = null;
+          }
+        }, 1000 * 30);
+      }
+
+      currentClient.write(chunk);
+      next();
+    },
+    destroy: (error: Error | null, next) => {
+      // Inform the output instance that there will be no more input data.
+      // In case there's an error, push it there as well.
+      output.setInputEnd(error);
+
+      if (currentClient) {
+        if (error) {
+          currentClient.destroy(error);
+        } else {
+          currentClient.end();
+        }
+      }
+      clearAllTimeouts();
+      next(null);
+    },
+    objectMode: true,
+  });
+
+  return [input, output];
+};
+
+export default streamKeeper;

--- a/jarvis_sdk_node/src/sdk/utils/stream/stream_splitter/__test__/stream_splitter.test.ts
+++ b/jarvis_sdk_node/src/sdk/utils/stream/stream_splitter/__test__/stream_splitter.test.ts
@@ -1,0 +1,643 @@
+import { ServiceError } from '@grpc/grpc-js';
+import { Readable } from 'stream';
+import IndexFixer from '../../index_fixer';
+import streamSplitter from '../stream_splitter';
+
+const getStreamResults = async (stream: Readable): Promise<unknown[]> => {
+  return new Promise((resolve, reject) => {
+    const results: unknown[] = [];
+    stream.on('data', (data: unknown[]) => {
+      results.push(...data);
+    });
+    stream.on('end', () => {
+      resolve(results);
+    });
+    stream.on('error', (err) => {
+      reject(err);
+    });
+  });
+};
+
+beforeEach(() => {
+  jest.spyOn(console, 'error').mockImplementation(() => {
+    //
+  });
+});
+
+afterEach(() => {
+  (console.error as unknown as jest.SpyInstance).mockRestore();
+});
+
+describe('when no modifiers are used', () => {
+  describe('when one item is pushed to the stream', () => {
+    let inputStream: Readable;
+    let outputStream: Readable;
+    let grpcRequestMakerFn: (
+      input: Record<string, unknown>,
+      cb: (err: ServiceError | null, value?: unknown) => void,
+    ) => void;
+    let payloadRequestMakerFn: (chunks: unknown[]) => Promise<Record<string, unknown>>;
+
+    beforeEach(() => {
+      inputStream = new Readable({
+        read: () => {
+          // Nothing needed to be done here
+        },
+        objectMode: true,
+      });
+
+      grpcRequestMakerFn = jest.fn().mockImplementation((payload, cb) => {
+        cb(
+          null,
+          payload.map((payloadItem: unknown, index: number) => ({
+            result: 'ok',
+            index: index,
+            email: (payloadItem as Record<string, unknown>).email,
+          })),
+        );
+      });
+
+      payloadRequestMakerFn = jest.fn().mockImplementation((chunks: unknown[]) => {
+        return Promise.resolve(
+          chunks.map((chunk) => ({
+            email: (chunk as Record<string, unknown>).email,
+            displayName: (chunk as Record<string, unknown>).name,
+          })),
+        );
+      });
+
+      inputStream.push({ email: 'test+1@gmail.com', name: 'Test #1' });
+      outputStream = streamSplitter(inputStream, grpcRequestMakerFn, 2, payloadRequestMakerFn);
+
+      // Wait till stream events are propagated
+      return new Promise((resolve) => setTimeout(resolve, 0));
+    });
+
+    it('does not send amy data to the payload maker', async () => {
+      expect(payloadRequestMakerFn).toBeCalledTimes(0);
+    });
+
+    it('does not send any data to the gRPC function', async () => {
+      expect(grpcRequestMakerFn).toBeCalledTimes(0);
+    });
+
+    describe('when input stream throws an error', () => {
+      let results: unknown;
+
+      beforeEach(async () => {
+        inputStream.destroy(new Error('Error message'));
+        results = await getStreamResults(outputStream);
+      });
+
+      it('prints an error message', () => {
+        expect(console.error as unknown as jest.SpyInstance).toBeCalledTimes(1);
+        expect(console.error as unknown as jest.SpyInstance).toBeCalledWith(
+          new Error('Error message'),
+        );
+      });
+
+      it('returns correct items', async () => {
+        expect(results).toEqual([
+          {
+            email: 'test+1@gmail.com',
+            index: 0,
+            result: 'ok',
+          },
+        ]);
+      });
+    });
+
+    describe('when EOF is sent to the stream', () => {
+      let results: unknown;
+
+      beforeEach(async () => {
+        inputStream.push(null);
+        results = await getStreamResults(outputStream);
+      });
+
+      it('returns correct items', async () => {
+        expect(results).toEqual([
+          {
+            email: 'test+1@gmail.com',
+            index: 0,
+            result: 'ok',
+          },
+        ]);
+      });
+
+      it('sends correct data to the payload maker', async () => {
+        expect(payloadRequestMakerFn).toBeCalledTimes(1);
+        expect(payloadRequestMakerFn).toBeCalledWith([
+          {
+            email: 'test+1@gmail.com',
+            name: 'Test #1',
+          },
+        ]);
+      });
+
+      it('sends correct data to the gRPC function', async () => {
+        expect(grpcRequestMakerFn).toBeCalledTimes(1);
+        expect(grpcRequestMakerFn).toBeCalledWith(
+          [
+            {
+              email: 'test+1@gmail.com',
+              displayName: 'Test #1',
+            },
+          ],
+          expect.any(Function),
+        );
+      });
+    });
+
+    describe('when another item is pushed to the stream', () => {
+      beforeEach(async () => {
+        inputStream.push({ email: 'test+2@gmail.com', name: 'Test #2' });
+
+        // Wait till stream events are propagated
+        return new Promise((resolve) => setTimeout(resolve, 0));
+      });
+
+      it('sends correct data to the payload maker', async () => {
+        expect(payloadRequestMakerFn).toBeCalledTimes(1);
+        expect(payloadRequestMakerFn).toBeCalledWith([
+          {
+            email: 'test+1@gmail.com',
+            name: 'Test #1',
+          },
+          {
+            email: 'test+2@gmail.com',
+            name: 'Test #2',
+          },
+        ]);
+      });
+
+      it('sends correct data to the gRPC function', async () => {
+        expect(grpcRequestMakerFn).toBeCalledTimes(1);
+        expect(grpcRequestMakerFn).toBeCalledWith(
+          [
+            {
+              email: 'test+1@gmail.com',
+              displayName: 'Test #1',
+            },
+            {
+              email: 'test+2@gmail.com',
+              displayName: 'Test #2',
+            },
+          ],
+          expect.any(Function),
+        );
+      });
+
+      describe('when EOF is sent to the stream', () => {
+        let results: unknown;
+
+        beforeEach(async () => {
+          inputStream.push(null);
+          results = await getStreamResults(outputStream);
+        });
+
+        it('returns correct items', async () => {
+          expect(results).toEqual([
+            {
+              email: 'test+1@gmail.com',
+              index: 0,
+              result: 'ok',
+            },
+            {
+              email: 'test+2@gmail.com',
+              index: 1,
+              result: 'ok',
+            },
+          ]);
+        });
+
+        it('sends correct data to the payload maker', async () => {
+          expect(payloadRequestMakerFn).toBeCalledTimes(1);
+          expect(payloadRequestMakerFn).toBeCalledWith([
+            {
+              email: 'test+1@gmail.com',
+              name: 'Test #1',
+            },
+            {
+              email: 'test+2@gmail.com',
+              name: 'Test #2',
+            },
+          ]);
+        });
+
+        it('sends correct data to the gRPC function', async () => {
+          expect(grpcRequestMakerFn).toBeCalledTimes(1);
+          expect(grpcRequestMakerFn).toBeCalledWith(
+            [
+              {
+                email: 'test+1@gmail.com',
+                displayName: 'Test #1',
+              },
+              {
+                email: 'test+2@gmail.com',
+                displayName: 'Test #2',
+              },
+            ],
+            expect.any(Function),
+          );
+        });
+      });
+
+      describe('when another item is pushed to the stream', () => {
+        beforeEach(async () => {
+          inputStream.push({ email: 'test+3@gmail.com', name: 'Test #3' });
+
+          // Wait till stream events are propagated
+          return new Promise((resolve) => setTimeout(resolve, 0));
+        });
+
+        it('sends correct data to the payload maker', async () => {
+          expect(payloadRequestMakerFn).toBeCalledTimes(1);
+          expect(payloadRequestMakerFn).toBeCalledWith([
+            {
+              email: 'test+1@gmail.com',
+              name: 'Test #1',
+            },
+            {
+              email: 'test+2@gmail.com',
+              name: 'Test #2',
+            },
+          ]);
+        });
+
+        it('sends correct data to the gRPC function', async () => {
+          expect(grpcRequestMakerFn).toBeCalledTimes(1);
+          expect(grpcRequestMakerFn).toBeCalledWith(
+            [
+              {
+                email: 'test+1@gmail.com',
+                displayName: 'Test #1',
+              },
+              {
+                email: 'test+2@gmail.com',
+                displayName: 'Test #2',
+              },
+            ],
+            expect.any(Function),
+          );
+        });
+
+        describe('when EOF is sent to the stream', () => {
+          let results: unknown;
+
+          beforeEach(async () => {
+            inputStream.push(null);
+            results = await getStreamResults(outputStream);
+          });
+
+          it('returns correct items', async () => {
+            expect(results).toEqual([
+              {
+                email: 'test+1@gmail.com',
+                index: 0,
+                result: 'ok',
+              },
+              {
+                email: 'test+2@gmail.com',
+                index: 1,
+                result: 'ok',
+              },
+              {
+                email: 'test+3@gmail.com',
+                index: 0,
+                result: 'ok',
+              },
+            ]);
+          });
+
+          it('sends correct data to the payload maker', async () => {
+            expect(payloadRequestMakerFn).toBeCalledTimes(2);
+            expect(payloadRequestMakerFn).nthCalledWith(1, [
+              {
+                email: 'test+1@gmail.com',
+                name: 'Test #1',
+              },
+              {
+                email: 'test+2@gmail.com',
+                name: 'Test #2',
+              },
+            ]);
+            expect(payloadRequestMakerFn).nthCalledWith(2, [
+              {
+                email: 'test+3@gmail.com',
+                name: 'Test #3',
+              },
+            ]);
+          });
+
+          it('sends correct data to the gRPC function', async () => {
+            expect(grpcRequestMakerFn).toBeCalledTimes(2);
+            expect(grpcRequestMakerFn).nthCalledWith(
+              1,
+              [
+                {
+                  email: 'test+1@gmail.com',
+                  displayName: 'Test #1',
+                },
+                {
+                  email: 'test+2@gmail.com',
+                  displayName: 'Test #2',
+                },
+              ],
+              expect.any(Function),
+            );
+            expect(grpcRequestMakerFn).nthCalledWith(
+              2,
+              [
+                {
+                  email: 'test+3@gmail.com',
+                  displayName: 'Test #3',
+                },
+              ],
+              expect.any(Function),
+            );
+          });
+
+          it('prints no error message', () => {
+            expect(console.error as unknown as jest.SpyInstance).toBeCalledTimes(0);
+          });
+        });
+      });
+    });
+  });
+});
+
+describe('when index fixer modifier is used', () => {
+  let inputStream: Readable;
+  let outputStream: Readable;
+  let grpcRequestMakerFn: jest.Mock<
+    void,
+    [Record<string, unknown>[], (err: ServiceError | null, value?: unknown) => void]
+  >;
+  let payloadRequestMakerFn: jest.Mock<Promise<Record<string, unknown>[]>, [unknown[]]>;
+  let results: unknown;
+  let indexFixer: IndexFixer<'index'>;
+  let indexFixerDataError: Error | null;
+  let indexFixerClientClosedError: Error | null;
+
+  beforeEach(() => {
+    inputStream = new Readable({
+      read: () => {
+        // Nothing needed to be done here
+      },
+      objectMode: true,
+    });
+
+    grpcRequestMakerFn = jest
+      .fn<void, [Record<string, unknown>[], (err: ServiceError | null, value?: unknown) => void]>()
+      .mockImplementation((payload, cb) => {
+        cb(
+          null,
+          payload.map((payloadItem: unknown, index: number) => ({
+            result: 'ok',
+            index: index,
+            email: (payloadItem as Record<string, unknown>).email,
+          })),
+        );
+      });
+
+    payloadRequestMakerFn = jest
+      .fn<Promise<Record<string, unknown>[]>, [unknown[]]>()
+      .mockImplementation((chunks: unknown[]) => {
+        return Promise.resolve(
+          chunks.map((chunk) => ({
+            email: (chunk as Record<string, unknown>).email,
+            displayName: (chunk as Record<string, unknown>).name,
+          })),
+        );
+      });
+
+    indexFixer = new IndexFixer('index');
+    outputStream = streamSplitter(inputStream, grpcRequestMakerFn, 2, payloadRequestMakerFn, [
+      {
+        onData: async (data, next) => {
+          if (indexFixerDataError) {
+            throw indexFixerDataError;
+          }
+          indexFixer.onData(data, next);
+        },
+        onClientClosed: async () => {
+          if (indexFixerClientClosedError) {
+            throw indexFixerClientClosedError;
+          }
+          indexFixer.onClientClosed();
+        },
+      },
+    ]);
+
+    indexFixerDataError = null;
+    indexFixerClientClosedError = null;
+
+    // Wait till stream events are propagated
+    return new Promise((resolve) => setTimeout(resolve, 0));
+  });
+
+  describe('when no error is thrown', () => {
+    it('does not send amy data to the payload maker', async () => {
+      expect(payloadRequestMakerFn).toBeCalledTimes(0);
+    });
+
+    it('does not send any data to the gRPC function', async () => {
+      expect(grpcRequestMakerFn).toBeCalledTimes(0);
+    });
+
+    describe('when 3 items are pushed to the stream', () => {
+      beforeEach(async () => {
+        inputStream.push({ email: 'test+1@gmail.com', name: 'Test #1' });
+        inputStream.push({ email: 'test+2@gmail.com', name: 'Test #2' });
+        inputStream.push({ email: 'test+3@gmail.com', name: 'Test #3' });
+        inputStream.push(null);
+        results = await getStreamResults(outputStream);
+      });
+
+      it('returns correct items', async () => {
+        expect(results).toEqual([
+          {
+            email: 'test+1@gmail.com',
+            index: 0,
+            result: 'ok',
+          },
+          {
+            email: 'test+2@gmail.com',
+            index: 1,
+            result: 'ok',
+          },
+          {
+            email: 'test+3@gmail.com',
+            index: 2,
+            result: 'ok',
+          },
+        ]);
+      });
+
+      it('sends correct data to the payload maker', async () => {
+        expect(payloadRequestMakerFn).toBeCalledTimes(2);
+        expect(payloadRequestMakerFn).nthCalledWith(1, [
+          {
+            email: 'test+1@gmail.com',
+            name: 'Test #1',
+          },
+          {
+            email: 'test+2@gmail.com',
+            name: 'Test #2',
+          },
+        ]);
+        expect(payloadRequestMakerFn).nthCalledWith(2, [
+          {
+            email: 'test+3@gmail.com',
+            name: 'Test #3',
+          },
+        ]);
+      });
+
+      it('sends correct data to the gRPC function', async () => {
+        expect(grpcRequestMakerFn).toBeCalledTimes(2);
+        expect(grpcRequestMakerFn).nthCalledWith(
+          1,
+          [
+            {
+              email: 'test+1@gmail.com',
+              displayName: 'Test #1',
+            },
+            {
+              email: 'test+2@gmail.com',
+              displayName: 'Test #2',
+            },
+          ],
+          expect.any(Function),
+        );
+        expect(grpcRequestMakerFn).nthCalledWith(
+          2,
+          [
+            {
+              email: 'test+3@gmail.com',
+              displayName: 'Test #3',
+            },
+          ],
+          expect.any(Function),
+        );
+      });
+
+      it('prints no error message', () => {
+        expect(console.error as unknown as jest.SpyInstance).toBeCalledTimes(0);
+      });
+    });
+  });
+
+  describe('when input stream throws an error', () => {
+    beforeEach(async () => {
+      inputStream.destroy(new Error('Error message'));
+      results = await getStreamResults(outputStream);
+    });
+
+    it('prints an error message', () => {
+      expect(console.error as unknown as jest.SpyInstance).toBeCalledTimes(1);
+      expect(console.error as unknown as jest.SpyInstance).toBeCalledWith(
+        new Error('Error message'),
+      );
+    });
+
+    it('returns correct items', async () => {
+      expect(results).toEqual([]);
+    });
+  });
+
+  describe('when request maker throws an error', () => {
+    let thrownError: Error;
+
+    beforeEach(async () => {
+      grpcRequestMakerFn.mockImplementation(() => {
+        throw new Error('GRPC request maker error');
+      });
+      inputStream.push({ email: 'test+1@gmail.com', name: 'Test #1' });
+      inputStream.push({ email: 'test+2@gmail.com', name: 'Test #2' });
+      inputStream.push(null);
+
+      return getStreamResults(outputStream).catch((err) => {
+        thrownError = err;
+      });
+    });
+
+    it('does not print any error message', () => {
+      expect(console.error as unknown as jest.SpyInstance).toBeCalledTimes(0);
+    });
+
+    it('throws an error', async () => {
+      expect(thrownError).toEqual(new Error('GRPC request maker error'));
+    });
+  });
+
+  describe('when request maker throws an error', () => {
+    let thrownError: Error;
+
+    beforeEach(async () => {
+      grpcRequestMakerFn.mockImplementation(() => {
+        throw new Error('GRPC request maker error');
+      });
+      inputStream.push({ email: 'test+1@gmail.com', name: 'Test #1' });
+      inputStream.push({ email: 'test+2@gmail.com', name: 'Test #2' });
+      inputStream.push(null);
+
+      return getStreamResults(outputStream).catch((err) => {
+        thrownError = err;
+      });
+    });
+
+    it('does not print any error message', () => {
+      expect(console.error as unknown as jest.SpyInstance).toBeCalledTimes(0);
+    });
+
+    it('throws an error', async () => {
+      expect(thrownError).toEqual(new Error('GRPC request maker error'));
+    });
+  });
+
+  describe('when data modifier throws an error', () => {
+    let thrownError: Error | undefined;
+
+    beforeEach(async () => {
+      indexFixerDataError = new Error('Modifier data error');
+      inputStream.push({ email: 'test+1@gmail.com', name: 'Test #1' });
+      inputStream.push(null);
+
+      return getStreamResults(outputStream).catch((err) => {
+        thrownError = err;
+      });
+    });
+
+    it('does not print any error message', () => {
+      expect(console.error as unknown as jest.SpyInstance).toBeCalledTimes(0);
+    });
+
+    it('throws an error', async () => {
+      expect(thrownError).toEqual(new Error('Modifier data error'));
+    });
+  });
+
+  describe('when client closed modifier throws an error', () => {
+    let thrownError: Error | undefined;
+
+    beforeEach(async () => {
+      indexFixerClientClosedError = new Error('Modifier client closed error');
+      inputStream.push({ email: 'test+1@gmail.com', name: 'Test #1' });
+      inputStream.push(null);
+
+      return getStreamResults(outputStream).catch((err) => {
+        thrownError = err;
+      });
+    });
+
+    it('does not print any error message', () => {
+      expect(console.error as unknown as jest.SpyInstance).toBeCalledTimes(0);
+    });
+
+    it('throws an error', async () => {
+      expect(thrownError).toEqual(new Error('Modifier client closed error'));
+    });
+  });
+});

--- a/jarvis_sdk_node/src/sdk/utils/stream/stream_splitter/index.ts
+++ b/jarvis_sdk_node/src/sdk/utils/stream/stream_splitter/index.ts
@@ -1,0 +1,1 @@
+export { default } from './stream_splitter';

--- a/jarvis_sdk_node/src/sdk/utils/stream/stream_splitter/stream_splitter.ts
+++ b/jarvis_sdk_node/src/sdk/utils/stream/stream_splitter/stream_splitter.ts
@@ -1,0 +1,164 @@
+import { ServiceError } from '@grpc/grpc-js';
+import { Readable } from 'stream';
+import { OutputModifier } from '../index_fixer';
+
+/**
+ * Loop over all modifiers with the returned response and return the changed value.
+ */
+const modifyResponse = <ResponseType>(response: ResponseType, modifiers: OutputModifier[]) => {
+  let promise: Promise<ResponseType> = Promise.resolve(response);
+  for (let modifierIndex = 0; modifierIndex < modifiers.length; ++modifierIndex) {
+    promise = promise.then(async (response: ResponseType) => {
+      return new Promise((resolve, reject) => {
+        const modifier = modifiers[modifierIndex];
+        modifier
+          .onData(response, (updatedResponse: unknown) => {
+            ++modifierIndex;
+            resolve(updatedResponse as ResponseType);
+          })
+          .catch(reject);
+      });
+    });
+  }
+
+  return promise;
+};
+
+/**
+ * Loop over all modifiers with the information that the opened connection with a client was closed.
+ */
+const sendClientClosedInfo = async (modifiers: OutputModifier[]) => {
+  await Promise.all(modifiers.map((modifier) => modifier.onClientClosed()));
+};
+
+/**
+ * This function helps to split big requests into smaller ones.
+ * @param inputStream The input stream.
+ * @param requestMaker The function which is called when a new gRPC function is about to be created.
+ * This can be e.g. importDigitalTwins gRPC function.
+ * @param maxCount The maximal number of objects retrieved from the input stream which can be sent
+ * in one gRPC request.
+ * @param onDataCb The transform function used for creating gRPC request function payload.
+ * ```
+ * (chunks: unknown[]) => {
+     return ImportDigitalTwinsRequest.create({
+       hashAlgorithm: hashAlgorithm.marshal(),
+       entities: chunks.map((chunk) => {
+         if (!(chunk instanceof ImportDigitalTwin)) {
+           throw new SdkError(SdkErrorCode.SDK_CODE_1, 'Incorrect stream object');
+         }
+ 
+         return chunk.marshal();
+       }),
+     });
+   }
+ * ```
+ * @param modifiers The list of modifiers which can change the returned response objects (e.g. IndexFixer).
+ * @returns The output stream which streames the returned response objects.
+ */
+const streamSplitter = <RequestType, ResponseType>(
+  inputStream: Readable,
+  requestMaker: (
+    input: RequestType,
+    cb: (err: ServiceError | null, value?: ResponseType) => void,
+  ) => void,
+  maxCount: number,
+  onDataCb: (chunks: unknown[]) => RequestType | Promise<RequestType>,
+  modifiers: OutputModifier[] = [],
+): Readable => {
+  let isFinished = false;
+  let processingRequestsCount = 0;
+
+  const output = new Readable({
+    read: () => {
+      // There's no need to do anything
+    },
+    objectMode: true,
+  });
+
+  const chunks: unknown[] = [];
+
+  const process = async () => {
+    ++processingRequestsCount;
+    let requestPayload = onDataCb(chunks.slice());
+    if (requestPayload instanceof Promise) {
+      requestPayload = await requestPayload;
+    }
+    return new Promise<void>((resolve) => {
+      requestMaker(
+        requestPayload as RequestType,
+        (err: ServiceError | null, response?: ResponseType) => {
+          let processPromise = Promise.resolve();
+          if (err) {
+            --processingRequestsCount;
+            output.destroy(err);
+            resolve();
+          } else {
+            if (response) {
+              processPromise = processPromise
+                .then(async () => {
+                  return modifyResponse(response, modifiers);
+                })
+                .then((response) => {
+                  output.push(response);
+                })
+                .catch((err) => {
+                  output.destroy(err);
+                });
+            }
+
+            processPromise
+              .then(async () => {
+                await sendClientClosedInfo(modifiers);
+                --processingRequestsCount;
+
+                if (processingRequestsCount === 0 && isFinished) {
+                  output.push(null);
+                }
+              })
+              .catch((err) => {
+                --processingRequestsCount;
+                output.destroy(err);
+              })
+              .then(resolve);
+          }
+        },
+      );
+    }).catch((err) => {
+      output.destroy(err);
+    });
+  };
+
+  inputStream.on('data', async (chunk) => {
+    chunks.push(chunk);
+    if (chunks.length >= maxCount) {
+      inputStream.pause();
+      await process();
+      inputStream.resume();
+
+      chunks.splice(0, chunks.length);
+    }
+  });
+
+  const endCallback = async () => {
+    isFinished = true;
+    if (processingRequestsCount === 0) {
+      if (chunks.length > 0) {
+        await process();
+      } else {
+        output.push(null);
+      }
+    }
+  };
+
+  inputStream.on('error', (err) => {
+    console.error(err);
+    endCallback();
+  });
+
+  inputStream.on('end', endCallback);
+
+  return output;
+};
+
+export default streamSplitter;


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: ./CONTRIBUTING.md
-->

<!-- _Please make sure to review and check all of these items:_ -->

# Description

This PR fixes two functions:
- `IngestClient.ingest`
  - This creates a streamed connection. A user sends data through the stream and after that results are returned via the stream as well. But if the stream is opened for a long time it hits a timeout issue which forces to close the connection. So the solution here is to regularly close and re-open the connection so that one connection is not opened for a long time.
- `IdentityClient.importDigitalTwins`
  - Added a support for streamed input
  - In this function the request in not sent as a stream, but as one request with payload which can have up to 1000 entries. This function checks how many entries a user wants to import and if there's more than 1000 entries, it will automatically create multiple requests where each of them contains at most 1000 entries.

This PR also contains a utility for fixing indexes in the responses. The results from one requests are always indexed from 0, so if there are created multiple requests because of a big payload, we need to fix the indexes so that they reflects the original request positions.

<!-- Please provide a description of the change here. -->

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

# Checklist

- [ ] `make test` passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows [commit guidelines](./doc/guides/commit-message.md#commit-message-guidelines)

## CHANGELOG

<!-- Please provide a brief description of changes here. -->
<!-- - [FIX] Fix a bug -->

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->
